### PR TITLE
Fix for launching from folders containing spaces ("Developer Preview")

### DIFF
--- a/src/applicationmodel.cpp
+++ b/src/applicationmodel.cpp
@@ -122,16 +122,17 @@ bool ApplicationModel::openNewInstance(const QString &appId)
 
     QProcess process;
     if (!item->exec.isEmpty()) {
-        QStringList args = item->exec.split(" ");
-        // process.setProgram(args.first());
-        // args.removeFirst();
-        // probono: Nah, we use the 'launch' command instead
         process.setProgram("launch");
-
-        if (!args.isEmpty()) {
-            process.setArguments(args);
-        }
-
+        
+        if(item->exec.contains("Filer"))
+           {
+               //we want to launch something trough filer, correct the args.
+               process.setArguments(item->exec.split(" "));
+           }else{
+                QStringList args;
+    	        args << item->exec;
+        	    process.setArguments(args);
+           }
     } else {
         process.setProgram(appId);
     }


### PR DESCRIPTION
https://github.com/helloSystem/Dock/issues/19
https://github.com/helloSystem/Dock/issues/11
Don't split arguments on whitespaces because whitespace named folders like "3D Apps" won't work.
BUT! Filer launches (Utilities, Preferences) rely on splitting on whitespaces so we need to correct the arguments when launching trough filer.
Both cases should work now.

The optimal solution would be to leave splitting on whitespaces alltogether (if possible) and use proper args, would need to properly investigate why was it done this way to avoid breaking stuff.